### PR TITLE
Use most generic UART functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ## [Unreleased] -->
 
 ## Released
+## [2.1.2] - 2022-12-28
+### Changed
+- Baudrate specific inter frame time is used at Modbus RTU internal function `_uart_read` of [serial.py](umodbus/serial.py) instead of constant value of 5ms
+
+### Fixed
+- ESP32 port specific `wait_tx_done` function replaced by generic wait time calculation in `_send` function of [serial.py](umodbus/serial.py), see #34
+- A 1ms delay has been added between turning the RS485 control pin on and sending the Modbus PDU in `_send` function of [serial.py](umodbus/serial.py)
+
 ## [2.1.1] - 2022-12-27
 ### Fixed
 - Removed unnecessary dependency to `micropython-urequests` from Docker files, setup guide and package setup file
@@ -182,8 +190,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PEP8 style issues on all files of [`lib/uModbus`](lib/uModbus)
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modbus/compare/2.1.1...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modbus/compare/2.1.2...develop
 
+[2.1.2]: https://github.com/brainelectronics/micropython-modbus/tree/2.1.2
 [2.1.1]: https://github.com/brainelectronics/micropython-modbus/tree/2.1.1
 [2.1.0]: https://github.com/brainelectronics/micropython-modbus/tree/2.1.0
 [2.0.0]: https://github.com/brainelectronics/micropython-modbus/tree/2.0.0

--- a/umodbus/serial.py
+++ b/umodbus/serial.py
@@ -175,7 +175,7 @@ class Serial(object):
                     break
 
             # wait for the maximum time between two frames
-            time.sleep(self._t35chars)
+            time.sleep_us(self._t35chars)
 
         return response
 

--- a/umodbus/serial.py
+++ b/umodbus/serial.py
@@ -173,7 +173,9 @@ class Serial(object):
                 # variable length function codes may require multiple reads
                 if self._exit_read(response):
                     break
-            time.sleep(0.05)
+
+            # wait for the maximum time between two frames
+            time.sleep(self._t35chars)
 
         return response
 

--- a/umodbus/serial.py
+++ b/umodbus/serial.py
@@ -246,6 +246,8 @@ class Serial(object):
 
         if self._ctrlPin:
             self._ctrlPin(1)
+            time.sleep_us(1000)     # wait until the control pin really changed
+            send_start_time = time.ticks_us()
 
         self._uart.write(serial_pdu)
 


### PR DESCRIPTION
### Changed
- Baudrate specific inter frame time is used at Modbus RTU internal function `_uart_read` of [serial.py](umodbus/serial.py) instead of constant value of 5ms

### Fixed
- ESP32 port specific `wait_tx_done` function replaced by generic wait time calculation in `_send` function of [serial.py](umodbus/serial.py), see #34
- A 1ms delay has been added between turning the RS485 control pin on and sending the Modbus PDU in `_send` function of [serial.py](umodbus/serial.py)