### PR TITLE
Remove hardcoded UART ID from Modbus RTU

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ## [Unreleased] -->
 
 ## Released
+## [2.1.3] - 2022-12-30
+### Fixed
+- `uart_id` can be specified during init of `ModbusRTU` and `Serial` class and is no longer hardcoded to `1`, but set as `1` by default to ensure backwards compability, see #7 and #43
+- RTU Client example and USAGE documentation updated with new `uart_id` parameter
+
 ## [2.1.2] - 2022-12-28
 ### Changed
 - Baudrate specific inter frame time is used at Modbus RTU internal function `_uart_read` of [serial.py](umodbus/serial.py) instead of constant value of 5ms
@@ -190,8 +195,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PEP8 style issues on all files of [`lib/uModbus`](lib/uModbus)
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modbus/compare/2.1.2...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modbus/compare/2.1.3...develop
 
+[2.1.3]: https://github.com/brainelectronics/micropython-modbus/tree/2.1.3
 [2.1.2]: https://github.com/brainelectronics/micropython-modbus/tree/2.1.2
 [2.1.1]: https://github.com/brainelectronics/micropython-modbus/tree/2.1.1
 [2.1.0]: https://github.com/brainelectronics/micropython-modbus/tree/2.1.0

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -241,6 +241,8 @@ based on TCP togehter with the latest provided
 All described functions require a successful setup of a Host communicating
 to/with a Client device which is providing the data and accepting the new data.
 
+#### TCP
+
 ```python
 from umodbus.tcp import TCP as ModbusTCPMaster
 
@@ -252,6 +254,31 @@ host = ModbusTCPMaster(
     slave_ip=slave_ip,
     slave_port=slave_tcp_port,
     timeout=5)                  # optional, default 5
+```
+
+#### RTU
+
+```python
+from umodbus.serial import Serial as ModbusRTUMaster
+
+slave_addr = 10                 # bus address of client
+
+# check MicroPython UART documentation
+# https://docs.micropython.org/en/latest/library/machine.UART.html
+# for Device/Port specific setup
+# RP2 needs "rtu_pins = (Pin(4), Pin(5))" whereas ESP32 can use any pin
+# the following example is for an ESP32
+rtu_pins = (25, 26)         # (TX, RX)
+host = ModbusRTUMaster(
+    addr=1,                 # bus address of this Host/Master, usually '1'
+    baudrate=9600,          # optional, default 9600
+    pins=rtu_pins,          # given as tuple (TX, RX)
+    # data_bits=8,          # optional, default 8
+    # stop_bits=1,          # optional, default 1
+    # parity=None,          # optional, default None
+    # ctrl_pin=12,          # optional, control DE/RE
+    # uart_id=1             # optional, see port specific documentation
+)
 ```
 
 #### Coils

--- a/examples/rtu_client_example.py
+++ b/examples/rtu_client_example.py
@@ -9,9 +9,10 @@ Do your stuff here, this file is similar to the loop() function on Arduino
 Create a Modbus RTU client (slave) which can be requested for data or set with
 specific values by a host device.
 
-The RTU communication pins can be choosen freely. The register definitions of
-the client as well as its connection settings like bus address and UART
-communication speed can be defined by the user.
+The RTU communication pins can be choosen freely (check MicroPython device/
+port specific limitations).
+The register definitions of the client as well as its connection settings like
+bus address and UART communication speed can be defined by the user.
 """
 
 # import modbus client classes
@@ -21,20 +22,33 @@ from umodbus.serial import ModbusRTU
 # RTU Slave setup
 # act as client, provide Modbus data via RTU to a host device
 # ModbusRTU can get serial requests from a host device to provide/set data
+# check MicroPython UART documentation
+# https://docs.micropython.org/en/latest/library/machine.UART.html
+# for Device/Port specific setup
+# RP2 needs "rtu_pins = (Pin(4), Pin(5))" whereas ESP32 can use any pin
+# the following example is for an ESP32
 rtu_pins = (25, 26)         # (TX, RX)
 slave_addr = 10             # address on bus as client
 baudrate = 9600
 client = ModbusRTU(
     addr=slave_addr,        # address on bus
     baudrate=baudrate,      # optional, default 9600
-    # data_bits=8,            # optional, default 8
-    # stop_bits=1,            # optional, default 1
-    # parity=None,            # optional, default None
-    pins=rtu_pins)
+    pins=rtu_pins,          # given as tuple (TX, RX)
+    # data_bits=8,          # optional, default 8
+    # stop_bits=1,          # optional, default 1
+    # parity=None,          # optional, default None
+    # ctrl_pin=12,          # optional, control DE/RE
+    # uart_id=1             # optional, see port specific documentation
+)
 
 # common slave register setup, to be used with the Master example above
 register_definitions = {
     "COILS": {
+        "RESET_REGISTER_DATA_COIL": {
+            "register": 42,
+            "len": 1,
+            "val": 0
+        },
         "EXAMPLE_COIL": {
             "register": 123,
             "len": 1,

--- a/umodbus/serial.py
+++ b/umodbus/serial.py
@@ -41,7 +41,7 @@ class ModbusRTU(Modbus):
     :param      parity:      The parity, default None
     :type       parity:      Optional[int]
     :param      pins:        The pins as list [TX, RX]
-    :type       pins:        List[int, int]
+    :type       pins:        List[Union[int, Pin], Union[int, Pin]]
     :param      ctrl_pin:    The control pin
     :type       ctrl_pin:    int
     :param      uart_id:     The ID of the used UART
@@ -53,7 +53,7 @@ class ModbusRTU(Modbus):
                  data_bits: int = 8,
                  stop_bits: int = 1,
                  parity: Optional[int] = None,
-                 pins: List[int, int] = None,
+                 pins: List[Union[int, Pin], Union[int, Pin]] = None,
                  ctrl_pin: int = None,
                  uart_id: int = 1):
         super().__init__(
@@ -76,7 +76,7 @@ class Serial(object):
                  data_bits: int = 8,
                  stop_bits: int = 1,
                  parity=None,
-                 pins: List[int, int] = None,
+                 pins: List[Union[int, Pin], Union[int, Pin]] = None,
                  ctrl_pin: int = None):
         """
         Setup Serial/RTU Modbus
@@ -92,7 +92,7 @@ class Serial(object):
         :param      parity:      The parity, default None
         :type       parity:      Optional[int]
         :param      pins:        The pins as list [TX, RX]
-        :type       pins:        List[int, int]
+        :type       pins:        List[Union[int, Pin], Union[int, Pin]]
         :param      ctrl_pin:    The control pin
         :type       ctrl_pin:    int
         """

--- a/umodbus/serial.py
+++ b/umodbus/serial.py
@@ -44,6 +44,8 @@ class ModbusRTU(Modbus):
     :type       pins:        List[int, int]
     :param      ctrl_pin:    The control pin
     :type       ctrl_pin:    int
+    :param      uart_id:     The ID of the used UART
+    :type       uart_id:     int
     """
     def __init__(self,
                  addr: int,
@@ -52,10 +54,11 @@ class ModbusRTU(Modbus):
                  stop_bits: int = 1,
                  parity: Optional[int] = None,
                  pins: List[int, int] = None,
-                 ctrl_pin: int = None):
+                 ctrl_pin: int = None,
+                 uart_id: int = 1):
         super().__init__(
             # set itf to Serial object, addr_list to [addr]
-            Serial(uart_id=1,
+            Serial(uart_id=uart_id,
                    baudrate=baudrate,
                    data_bits=data_bits,
                    stop_bits=stop_bits,


### PR DESCRIPTION
### Fixed
- `uart_id` can be specified during init of `ModbusRTU` and `Serial` class and is no longer hardcoded to `1`, but set as `1` by default to ensure backwards compability, see #7 and #43
- RTU Client example and USAGE documentation updated with new `uart_id` parameter
