### PR TITLE
Support mip installation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# 4 space indentation
+[*.py]
+indent_size = 4
+
+[*.json]
+indent_size = 4
+
+# 2 space indentation
+[*.yml]
+indent_size = 2
+
+[*.{md,rst}]
+indent_size = 4
+trim_trailing_whitespace = false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,3 @@
+---
+
 blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,3 +1,5 @@
+---
+
 name: "Default issue"
 description: Report any kind of issue
 body:
@@ -13,7 +15,8 @@ body:
     id: reproduction
     attributes:
       label: Reproduction steps
-      description: Please enter an explicit description to reproduce this issue
+      description: |
+        Please enter an explicit description to reproduce this issue
       value: |
         1.
         2.
@@ -52,13 +55,19 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      description: >
+        Please copy and paste any relevant log output.
+        This will be automatically formatted into code, so no need for
+        backticks.
       render: bash
   - type: textarea
     id: usercode
     attributes:
       label: User code
-      description: Please copy and paste any relevant user code. This will be automatically formatted into Python code, so no need for backticks.
+      description: >
+        Please copy and paste any relevant user code.
+        This will be automatically formatted into Python code, so no need for
+        backticks.
       render: python
   - type: textarea
     id: additional

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -52,6 +52,21 @@ body:
     validations:
       required: true
   - type: textarea
+    id: modbus-version
+    attributes:
+      label: MicroPython Modbus version
+      description: Which version of this lib are you using?
+      value: |
+        # e.g. v2.3.3
+        # use the following command to get the used version
+        import os
+        from umodbus import version
+        print('MicroPython infos:', os.uname())
+        print('Used micropthon-modbus version:', version.__version__))
+      render: python
+    validations:
+      required: true
+  - type: textarea
     id: logs
     attributes:
       label: Relevant log output

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
-# this file is *not* meant to cover or endorse the use of GitHub Actions, but rather to
-# help make automated releases for this project
+---
+
+# this file is *not* meant to cover or endorse the use of GitHub Actions, but
+# rather to help make automated releases for this project
 
 name: Upload Python Package
 
@@ -15,42 +17,42 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.9'
-    - name: Install build dependencies
-      run: |
-        if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
-    - name: Build package
-      run: |
-        changelog2version \
-          --changelog_file changelog.md \
-          --version_file umodbus/version.py \
-          --version_file_type py \
-          --debug
-        python setup.py sdist
-        rm dist/*.orig
-      # sdist call create non conform twine files *.orig, remove them
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1.5
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        skip_existing: true
-        verbose: true
-        print_hash: true
-    - name: 'Create changelog based release'
-      uses: brainelectronics/changelog-based-release@v1
-      with:
-        # note you'll typically need to create a personal access token
-        # with permissions to create releases in the other repo
-        # or you set the "contents" permissions to "write" as in this example
-        changelog-path: changelog.md
-        tag-name-prefix: ''
-        tag-name-extension: ''
-        release-name-prefix: ''
-        release-name-extension: ''
-        draft-release: true
-        prerelease: false
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Install build dependencies
+        run: |
+          if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
+      - name: Build package
+        run: |
+          changelog2version \
+            --changelog_file changelog.md \
+            --version_file umodbus/version.py \
+            --version_file_type py \
+            --debug
+          python setup.py sdist
+          rm dist/*.orig
+        # sdist call create non conform twine files *.orig, remove them
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1.5
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip_existing: true
+          verbose: true
+          print_hash: true
+      - name: 'Create changelog based release'
+        uses: brainelectronics/changelog-based-release@v1
+        with:
+          # note you'll typically need to create a personal access token
+          # with permissions to create releases in the other repo
+          # or you set the "contents" permissions to "write" as in this example
+          changelog-path: changelog.md
+          tag-name-prefix: ''
+          tag-name-extension: ''
+          release-name-prefix: ''
+          release-name-extension: ''
+          draft-release: true
+          prerelease: false

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,5 +1,7 @@
-# this file is *not* meant to cover or endorse the use of GitHub Actions, but rather to
-# help make automated releases for this project
+---
+
+# this file is *not* meant to cover or endorse the use of GitHub Actions, but
+# rather to help make automated test releases for this project
 
 name: Upload Python Package to test.pypi.org
 
@@ -12,55 +14,55 @@ jobs:
   test-deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.9'
-    - name: Install build dependencies
-      run: |
-        if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
-    - name: Build package
-      run: |
-        changelog2version \
-          --changelog_file changelog.md \
-          --version_file umodbus/version.py \
-          --version_file_type py \
-          --additional_version_info="-rc${{ github.run_number }}.dev${{ github.event.number }}" \
-          --debug
-        python setup.py sdist
-    - name: Test built package
-      # sdist call creates non twine conform "*.orig" files, remove them
-      run: |
-        rm dist/*.orig
-        twine check dist/*.tar.gz
-    - name: Archive build package artifact
-      uses: actions/upload-artifact@v3
-      with:
-        # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
-        # ${{ github.repository }} and ${{ github.ref_name }} can't be used for artifact name due to unallowed '/'
-        name: dist_repo.${{ github.event.repository.name }}_sha.${{ github.sha }}_build.${{ github.run_number }}
-        path: dist/*.tar.gz
-        retention-days: 14
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1.5
-      with:
-        repository_url: https://test.pypi.org/legacy/
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        skip_existing: true
-        verbose: true
-        print_hash: true
-    - name: 'Create changelog based prerelease'
-      uses: brainelectronics/changelog-based-release@v1
-      with:
-        # note you'll typically need to create a personal access token
-        # with permissions to create releases in the other repo
-        # or you set the "contents" permissions to "write" as in this example
-        changelog-path: changelog.md
-        tag-name-prefix: ''
-        tag-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}'
-        release-name-prefix: ''
-        release-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}'
-        draft-release: true
-        prerelease: true
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Install build dependencies
+        run: |
+          if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
+      - name: Build package
+        run: |
+          changelog2version \
+            --changelog_file changelog.md \
+            --version_file umodbus/version.py \
+            --version_file_type py \
+            --additional_version_info="-rc${{ github.run_number }}.dev${{ github.event.number }}" \
+            --debug
+          python setup.py sdist
+      - name: Test built package
+        # sdist call creates non twine conform "*.orig" files, remove them
+        run: |
+          rm dist/*.orig
+          twine check dist/*.tar.gz
+      - name: Archive build package artifact
+        uses: actions/upload-artifact@v3
+        with:
+          # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+          # ${{ github.repository }} and ${{ github.ref_name }} can't be used for artifact name due to unallowed '/'
+          name: dist_repo.${{ github.event.repository.name }}_sha.${{ github.sha }}_build.${{ github.run_number }}
+          path: dist/*.tar.gz
+          retention-days: 14
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1.5
+        with:
+          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          skip_existing: true
+          verbose: true
+          print_hash: true
+      - name: 'Create changelog based prerelease'
+        uses: brainelectronics/changelog-based-release@v1
+        with:
+          # note you'll typically need to create a personal access token
+          # with permissions to create releases in the other repo
+          # or you set the "contents" permissions to "write" as in this example
+          changelog-path: changelog.md
+          tag-name-prefix: ''
+          tag-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}'
+          release-name-prefix: ''
+          release-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}'
+          draft-release: true
+          prerelease: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ on:
     branches-ignore:
       - 'main'
       - 'develop'
+  pull_request:
+    branches:
+      - 'main'
+      - 'develop'
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+---
+
+# This workflow will install Python dependencies, run tests and lint with a
+# specific Python version
+# For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Test Python package
 
@@ -17,46 +21,49 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.9'
-    - name: Install test dependencies
-      run: |
-        pip install -r requirements-test.txt
-    - name: Lint with flake8
-      run: |
-        flake8 .
-    - name: Install deploy dependencies
-      run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
-    - name: Execute tests
-      run: |
-        docker build --tag micropython-test --file Dockerfile.tests .
-    - name: Run Client/Host TCP example
-      run: |
-        docker compose up --build --exit-code-from micropython-host
-    - name: Run Client/Host TCP test
-      run: |
-        docker compose -f docker-compose-tcp-test.yaml up --build --exit-code-from micropython-host
-    - name: Run Client/Host RTU example
-      run: |
-        docker compose -f docker-compose-rtu.yaml up --build --exit-code-from micropython-host
-    - name: Run Client/Host RTU test
-      run: |
-        docker compose -f docker-compose-rtu-test.yaml up --build --exit-code-from micropython-host
-    - name: Build package
-      run: |
-        changelog2version \
-          --changelog_file changelog.md \
-          --version_file umodbus/version.py \
-          --version_file_type py \
-          --debug
-        python setup.py sdist
-        rm dist/*.orig
-    - name: Test built package
-      run: |
-        twine check dist/*
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Install test dependencies
+        run: |
+          pip install -r requirements-test.txt
+      - name: Lint with flake8
+        run: |
+          flake8 .
+      - name: Lint with yamllint
+        run: |
+          yamllint .
+      - name: Install deploy dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
+      - name: Execute tests
+        run: |
+          docker build --tag micropython-test --file Dockerfile.tests .
+      - name: Run Client/Host TCP example
+        run: |
+          docker compose up --build --exit-code-from micropython-host
+      - name: Run Client/Host TCP test
+        run: |
+          docker compose -f docker-compose-tcp-test.yaml up --build --exit-code-from micropython-host
+      - name: Run Client/Host RTU example
+        run: |
+          docker compose -f docker-compose-rtu.yaml up --build --exit-code-from micropython-host
+      - name: Run Client/Host RTU test
+        run: |
+          docker compose -f docker-compose-rtu-test.yaml up --build --exit-code-from micropython-host
+      - name: Build package
+        run: |
+          changelog2version \
+            --changelog_file changelog.md \
+            --version_file umodbus/version.py \
+            --version_file_type py \
+            --debug
+          python setup.py sdist
+          rm dist/*.orig
+      - name: Test built package
+        run: |
+          twine check dist/*

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,5 @@
+---
+
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
@@ -17,4 +19,4 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
-  - requirements: docs/requirements.txt
+    - requirements: docs/requirements.txt

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,15 @@
+---
+
+extends: default
+
+ignore:
+  - .tox
+  - .venv
+  - .idea
+  - .thinking
+
+rules:
+  line-length:
+    level: warning
+    ignore:
+      - .github/workflows/*

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ station.active(True)
 station.connect('SSID', 'PASSWORD')
 time.sleep(1)
 print('Device connected to network: {}'.format(station.isconnected()))
-mip.install('micropython-modbus', index='https://pypi.org/pypi')
+mip.install('github:brainelectronics/micropython-modbus')
 print('Installation completed')
 machine.soft_reset()
 ```
@@ -168,7 +168,7 @@ device, connect to a network and install them via `upip` as follows
 ```python
 # with MicroPython version 1.19.1 or newer
 import mip
-mip.install('micropython-brainelectronics-helpers', index='https://pypi.org/pypi')
+mip.install('github:brainelectronics/micropython-modules')
 
 # before MicroPython version 1.19.1
 import upip

--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ## [Unreleased] -->
 
 ## Released
-## [2.4.0] - 2023-03-19
+## [2.3.4] - 2023-03-20
 ### Added
 - `package.json` for `mip` installation with MicroPython v1.19.1 or newer
 - `.editorconfig` for common editor settings
@@ -282,9 +282,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PEP8 style issues on all files of [`lib/uModbus`](lib/uModbus)
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modbus/compare/2.4.0...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modbus/compare/2.3.4...develop
 
-[2.4.0]: https://github.com/brainelectronics/micropython-modbus/tree/2.4.0
+[2.3.4]: https://github.com/brainelectronics/micropython-modbus/tree/2.3.4
 [2.3.3]: https://github.com/brainelectronics/micropython-modbus/tree/2.3.3
 [2.3.2]: https://github.com/brainelectronics/micropython-modbus/tree/2.3.2
 [2.3.1]: https://github.com/brainelectronics/micropython-modbus/tree/2.3.1

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ## [Unreleased] -->
 
 ## Released
+## [2.4.0] - 2023-03-19
+### Added
+- `package.json` for `mip` installation with MicroPython v1.19.1 or newer
+- `.editorconfig` for common editor settings
+- `.yamllint` to lint all used YAML files
+- `yamllint` package to the `requirements-test.txt` file
+- Run YAML linter on test workflow
+- Modbus version input field in issues template
+
+### Changed
+- Test workflow is also running on pull requests as the workflow is not executed on branches of contributors
+
+### Fixed
+- YAML style violation in Docker, workflow and issue files
+- `mip` installation commands in `README` and `INSTALLATION`
+
 ## [2.3.3] - 2023-01-29
 ### Fixed
 - Add link to RTU documentation examples from RTU examples files and root [README](README.md), relates to #7
@@ -266,8 +282,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PEP8 style issues on all files of [`lib/uModbus`](lib/uModbus)
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modbus/compare/2.3.3...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modbus/compare/2.4.0...develop
 
+[2.4.0]: https://github.com/brainelectronics/micropython-modbus/tree/2.4.0
 [2.3.3]: https://github.com/brainelectronics/micropython-modbus/tree/2.3.3
 [2.3.2]: https://github.com/brainelectronics/micropython-modbus/tree/2.3.2
 [2.3.1]: https://github.com/brainelectronics/micropython-modbus/tree/2.3.1

--- a/docker-compose-rtu-test.yaml
+++ b/docker-compose-rtu-test.yaml
@@ -1,3 +1,5 @@
+---
+
 #
 # build all non-image containers
 # $ docker-compose -f docker-compose-rtu-test.yaml build
@@ -21,7 +23,8 @@ services:
     expose:
       - "65433"
     ports:
-      - "65433:65433" # reach "micropython-client" at 172.25.0.2:65433, see networks
+      # reach "micropython-client" at 172.25.0.2:65433, see networks
+      - "65433:65433"
     networks:
       serial_bridge:
         # fix IPv4 address to be known and in the MicroPython scripts

--- a/docker-compose-rtu.yaml
+++ b/docker-compose-rtu.yaml
@@ -1,3 +1,5 @@
+---
+
 #
 # build all non-image containers
 # $ docker-compose build
@@ -20,7 +22,8 @@ services:
     expose:
       - "65433"
     ports:
-      - "65433:65433" # reach "micropython-client" at 172.25.0.2:65433, see networks
+      # reach "micropython-client" at 172.25.0.2:65433, see networks
+      - "65433:65433"
     networks:
       serial_bridge:
         # fix IPv4 address to be known and in the MicroPython scripts

--- a/docker-compose-tcp-test.yaml
+++ b/docker-compose-tcp-test.yaml
@@ -1,3 +1,5 @@
+---
+
 #
 # build all non-image containers
 # $ docker-compose -f docker-compose-tcp-test.yaml build
@@ -20,7 +22,8 @@ services:
     expose:
       - "502"
     ports:
-      - "502:502" # reach "micropython-client" at 172.24.0.2:502, see networks
+      # reach "micropython-client" at 172.24.0.2:502, see networks
+      - "502:502"
     networks:
       my_bridge:
         # fix IPv4 address to be known and in the MicroPython scripts

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,5 @@
+---
+
 #
 # build all non-image containers
 # $ docker-compose build
@@ -19,7 +21,8 @@ services:
     expose:
       - "502"
     ports:
-      - "502:502" # reach "micropython-client" at 172.24.0.2:502, see networks
+      # reach "micropython-client" at 172.24.0.2:502, see networks
+      - "502:502"
     networks:
       my_bridge:
         # fix IPv4 address to be known and in the MicroPython scripts

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -36,25 +36,36 @@ versions check the [upip section below](#install-with-upip)
 	micropython-lib as its index by default.
 ```
 
-As this library is pushed to [PyPi][ref-micropython-modbus-pypi] and
-[TestPyPi][ref-micropython-modbus-test-pypi], but not the default
-[micropython-lib index](https://micropython.org/pi/v2) the additional index
-has to be specified explicitly.
+As this library is not pushed to the default
+[micropython-lib index](https://micropython.org/pi/v2), the installation has
+to be done via the package definition file (`package.json`) provided with this
+repo.
 
 ```python
 import mip
-mip.install('micropython-modbus', index='https://pypi.org/pypi')
+mip.install('github:brainelectronics/micropython-modbus')
 ```
 
-In order to install the latest release candidate version, set the index to
-`'https://test.pypi.org/pypi'`
+In order to install the latest release candidate version, select a version from
+the [repo tags overview][ref-github-micropython-modbus-tags]
 
 ```python
 import mip
-mip.install('micropython-modbus', index='https://test.pypi.org/pypi')
+mip.install('github:brainelectronics/micropython-modbus', version='2.3.3-rc31.dev59')
 ```
 
 ### Install with upip
+
+This library is pushed to [PyPi][ref-micropython-modbus-pypi] and
+[TestPyPi][ref-micropython-modbus-test-pypi]. The installation from those
+package indices is currently not supported with MicroPython v1.19.1 or newer.
+The package can be installed on older MicroPython versions with the following
+commands.
+
+```{note}
+`upip` is not able to install a specific version of a package. It will always
+use the latest available version.
+```
 
 ```python
 import upip
@@ -62,7 +73,7 @@ upip.install('micropython-modbus')
 ```
 
 In order to install the latest release candidate version, use the following
-commands
+commands.
 
 ```python
 import upip
@@ -87,14 +98,14 @@ To install the latest officially released library version use the following
 command
 
 ```bash
-mpremote connect /dev/tty.SLAB_USBtoUART mip install --index https://pypi.org/pypi micropython-modbus
+mpremote connect /dev/tty.SLAB_USBtoUART mip install github:brainelectronics/micropython-modbus
 ```
 
 In order to install the latest release candidate version, use the following
 command
 
 ```bash
-mpremote connect /dev/tty.SLAB_USBtoUART mip install --index https://test.pypi.org/pypi micropython-modbus
+mpremote connect /dev/tty.SLAB_USBtoUART mip install github:brainelectronics/micropython-modbus
 ```
 
 ### Manually
@@ -158,6 +169,7 @@ README for further instructions.
 
 <!-- Links -->
 [ref-micropython-modbus-test-pypi]: https://test.pypi.org/project/micropython-modbus/
+[ref-github-micropython-modbus-tags]: https://github.com/brainelectronics/micropython-modbus/tags
 [ref-micropython-modbus-pypi]: https://pypi.org/project/micropython-modbus/
 [ref-mpremote]: https://docs.micropython.org/en/v1.19.1/reference/mpremote.html#mpremote
 [ref-mpremote-doc]: https://docs.micropython.org/en/v1.19.1/reference/mpremote.html

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+    "urls": [
+        [
+            "umodbus/__init__.py",
+            "github:brainelectronics/micropython-modbus/umodbus/__init__.py"
+        ],
+        [
+            "umodbus/common.py",
+            "github:brainelectronics/micropython-modbus/umodbus/common.py"
+        ],
+        [
+            "umodbus/const.py",
+            "github:brainelectronics/micropython-modbus/umodbus/const.py"
+        ],
+        [
+            "umodbus/functions.py",
+            "github:brainelectronics/micropython-modbus/umodbus/functions.py"
+        ],
+        [
+            "umodbus/modbus.py",
+            "github:brainelectronics/micropython-modbus/umodbus/modbus.py"
+        ],
+        [
+            "umodbus/serial.py",
+            "github:brainelectronics/micropython-modbus/umodbus/serial.py"
+        ],
+        [
+            "umodbus/tcp.py",
+            "github:brainelectronics/micropython-modbus/umodbus/tcp.py"
+        ],
+        [
+            "umodbus/typing.py",
+            "github:brainelectronics/micropython-modbus/umodbus/typing.py"
+        ],
+        [
+            "umodbus/version.py",
+            "github:brainelectronics/micropython-modbus/umodbus/version.py"
+        ]
+    ],
+    "deps": [
+    ],
+    "version": "2.3.4"
+}
+

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@
 flake8>=5.0.0,<6
 coverage>=6.4.2,<7
 nose2>=0.12.0,<1
+yamllint>=1.29,<2


### PR DESCRIPTION
### Added
- `package.json` for `mip` installation with MicroPython v1.19.1 or newer
- `.editorconfig` for common editor settings
- `.yamllint` to lint all used YAML files
- `yamllint` package to the `requirements-test.txt` file
- Run YAML linter on test workflow
- Modbus version input field in issues template

### Changed
- Test workflow is also running on pull requests as the workflow is not executed on branches of contributors

### Fixed
- YAML style violation in Docker, workflow and issue files
- `mip` installation commands in `README` and `INSTALLATION`