### PR TITLE
#63: Create initial CITATION file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,15 +1,17 @@
 cff-version: 1.2.0
 message: "Feel free to use this, if you want to cite this library."
 authors:
-- name: "Pycom Limited"
-- given-names: "Jones"
-- name: "The Micropython Modbus team"
-title: "Micropython Modbus"
-abstract: "A lightweight Modbus TCP/RTU library for Micropython"
+  - name: "Pycom Limited"
+  - affiliation: brainelectronics
+    family-names: Scharpf
+    given-names: Jonas
+- name: "The MicroPython Modbus team"
+title: "MicroPython Modbus"
+abstract: "A lightweight Modbus TCP/RTU library for MicroPython"
 version: "2.3.4"
 license: "GPLv3"
-date-released: 2017-12-18
+date-released: 2023-03-20
 url: "https://github.com/brainelectronics/micropython-modbus"
 keywords:
-- micropython
-- modbus
+  - micropython
+  - modbus

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+cff-version: 1.2.0
+message: "Feel free to use this, if you want to cite this library."
+authors:
+- name: "Pycom Limited"
+- given-names: "Jones"
+- name: "The Micropython Modbus team"
+title: "Micropython Modbus"
+abstract: "A lightweight Modbus TCP/RTU library for Micropython"
+version: "2.3.4"
+license: "GPLv3"
+date-released: 2017-12-18
+url: "https://github.com/brainelectronics/micropython-modbus"
+keywords:
+- micropython
+- modbus

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,17 +1,26 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
 cff-version: 1.2.0
-message: "Feel free to use this, if you want to cite this library."
+title: MicroPython Modbus
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
 authors:
-  - name: "Pycom Limited"
-  - affiliation: brainelectronics
+  - affiliation: Pycom Limited
+  - given-names: Jonas
     family-names: Scharpf
-    given-names: Jonas
-- name: "The MicroPython Modbus team"
-title: "MicroPython Modbus"
-abstract: "A lightweight Modbus TCP/RTU library for MicroPython"
-version: "2.3.4"
-license: "GPLv3"
-date-released: 2023-03-20
-url: "https://github.com/brainelectronics/micropython-modbus"
+    affiliation: brainelectronics
+  - affiliation: The MicroPython Modbus team
+repository-code: 'https://github.com/brainelectronics/micropython-modbus/'
+url: 'https://brainelectronics.de'
+repository-artifact: 'https://pypi.org/project/micropython-modbus/'
+abstract: A lightweight Modbus TCP/RTU library for Micropython
 keywords:
   - micropython
   - modbus
+license: AGPL-3.0
+commit: '2975f78'
+version: 2.3.4
+date-released: '2023-03-20'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,11 +8,11 @@ message: >-
   metadata from this file.
 type: software
 authors:
-  - affiliation: Pycom Limited
+  - name: Pycom Limited
   - given-names: Jonas
     family-names: Scharpf
     affiliation: brainelectronics
-  - affiliation: The MicroPython Modbus team
+  - name: The MicroPython Modbus team
 repository-code: 'https://github.com/brainelectronics/micropython-modbus/'
 url: 'https://brainelectronics.de'
 repository-artifact: 'https://pypi.org/project/micropython-modbus/'


### PR DESCRIPTION
Creates an initial CITATION.cff file for #63 - right now, the first author is the original (Pycom Limited), the second author is the owner of the repository (Jones/brainelectronics - not sure which one to use) and the remaining authors are folded under "The Micropython Modbus team", like how it is done with e.g. [Pytorch Lightning](https://github.com/Lightning-AI/lightning/blob/master/CITATION.cff).

Feel free to suggest any changes @brainelectronics @beyonlo @wthomson. Note: typically, if there are more than 3 authors they get folded under "et al.", so I do not think adding more authors would make a difference most of the time. Also, although it would be nice to, not all authors need to be credited - and because I am interested in citing this repository for my academic work, I think it would be best not to include my involvement in the CITATION file.