### PR TITLE
Fix timing issues with UART communication

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ## [Unreleased] -->
 
 ## Released
+## [2.3.5] - 2023-07-01
+### Fixed
+- Time between RS485 control pin raise and UART transmission reduced by 80% from 1000us to 200us
+- The RS485 control pin is lowered as fast as possible by using `time.sleep_us()` instead of `machine.idle()` which uses an IRQ on the order of milliseconds. This kept the control pin active longer than necessary, causing the response message to be missed at higher baud rates. This applies only to MicroPython firmwares below v1.20.0
+- The following fixes were provided by @wpyoga
+- RS485 control pin handling fixed by using UART `flush` function, see #68
+- Invalid CRC while reading multiple coils and fixed, see #50 and #52
+
 ## [2.3.4] - 2023-03-20
 ### Added
 - `package.json` for `mip` installation with MicroPython v1.19.1 or newer
@@ -282,8 +290,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PEP8 style issues on all files of [`lib/uModbus`](lib/uModbus)
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-modbus/compare/2.3.4...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-modbus/compare/2.3.5...develop
 
+[2.3.5]: https://github.com/brainelectronics/micropython-modbus/tree/2.3.5
 [2.3.4]: https://github.com/brainelectronics/micropython-modbus/tree/2.3.4
 [2.3.3]: https://github.com/brainelectronics/micropython-modbus/tree/2.3.3
 [2.3.2]: https://github.com/brainelectronics/micropython-modbus/tree/2.3.2

--- a/fakes/machine.py
+++ b/fakes/machine.py
@@ -425,6 +425,9 @@ class UART(object):
         """Send a break condition on the bus"""
         raise MachineError('Not yet implemented')
 
+    '''
+    # flush introduced in MicroPython v1.20.0
+    # use manual timing calculation for testing
     def flush(self) -> None:
         """
         Waits until all data has been sent
@@ -434,6 +437,7 @@ class UART(object):
         Only available with newer versions than 1.19
         """
         raise MachineError('Not yet implemented')
+    '''
 
     def txdone(self) -> bool:
         """

--- a/umodbus/serial.py
+++ b/umodbus/serial.py
@@ -166,14 +166,16 @@ class Serial(CommonModbusFunctions):
 
     def _uart_read(self) -> bytearray:
         """
-        Read up to 40 bytes from UART
+        Read incoming slave response from UART
 
         :returns:   Read content
         :rtype:     bytearray
         """
         response = bytearray()
 
-        for x in range(1, 40):
+        # TODO: use some kind of hint or user-configurable delay
+        #       to determine this loop counter
+        for x in range(1, 120):
             if self._uart.any():
                 # WiPy only
                 # response.extend(self._uart.readall())

--- a/umodbus/serial.py
+++ b/umodbus/serial.py
@@ -143,17 +143,19 @@ class Serial(CommonModbusFunctions):
         :param      response:    The response
         :type       response:    bytearray
 
-        :returns:   State of basic read response evaluation
+        :returns:   State of basic read response evaluation,
+                    True if entire response has been read
         :rtype:     bool
         """
-        if response[1] >= Const.ERROR_BIAS:
-            if len(response) < Const.ERROR_RESP_LEN:
+        response_len = len(response)
+        if response_len >= 2 and response[1] >= Const.ERROR_BIAS:
+            if response_len < Const.ERROR_RESP_LEN:
                 return False
-        elif (Const.READ_COILS <= response[1] <= Const.READ_INPUT_REGISTER):
+        elif response_len >= 3 and (Const.READ_COILS <= response[1] <= Const.READ_INPUT_REGISTER):
             expected_len = Const.RESPONSE_HDR_LENGTH + 1 + response[2] + Const.CRC_LENGTH
-            if len(response) < expected_len:
+            if response_len < expected_len:
                 return False
-        elif len(response) < Const.FIXED_RESP_LEN:
+        elif response_len < Const.FIXED_RESP_LEN:
             return False
 
         return True


### PR DESCRIPTION
This pull request fixes timing issues when sending a command and receiving a response:
- Sometimes the initial bytes are garbled and truncated #73 
- When reading a long response, sometimes the end of the response is truncated

The missing initial bytes issue is apparent when we use a TTL-to-RS485 converter board that does not have automatic flow control. This is usually in the form of an EN pin, or DE & ~RE pin jumpered together. They are equivalent. This can be seen in the extremely popular [MAX485](https://www.analog.com/en/products/max485.html) chip. This is caused by disabling the EN pin too late -- thus messing up the initial slave response.

The fix for the issue with receiving long slave responses is not perfect, but should be good enough for now. I was able to consistently trigger this issue by reading many (64, 96, and even 125) registers at once. An ideal solution would involve letting the user/caller specify the timeout value for reading a response.

P.S. Apologies to @brainelectronics , I did not see your PR #73 before going with this approach. However, I believe this solution will fix both your problem (ticks rollover) and the initial bytes being truncated.

P.P.S. This pull request should (may) also fix these issues:
- #52 
- #68 by @ondrej1024
- #50 by @j-broome