### PR TITLE
Use git attributes for better python diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.py diff=python


### PR DESCRIPTION
Use `.gitattributes` file:

```
*.py diff=python
```

So that `git diff` shows the Python function name:

```
@@ -284,7 +284,7 @@ def _send_receive(self,
```

Instead of just the class name:

```
@@ -284,7 +284,7 @@ class Serial(CommonModbusFunctions):
```