### PR TITLE
Bugfix: 'on_get_cb': return value was swallowed

### DIFF
--- a/umodbus/modbus.py
+++ b/umodbus/modbus.py
@@ -183,14 +183,12 @@ class Modbus(object):
 
         if address in self._register_dict[reg_type]:
 
-            if self._register_dict[reg_type][address].get('on_get_cb', 0):
-                vals = self._create_response(request=request,
-                                             reg_type=reg_type)
-                _cb = self._register_dict[reg_type][address]['on_get_cb']
+            vals = self._create_response(request=request, reg_type=reg_type)
+            _cb = self._register_dict[reg_type][address].get('on_get_cb', None)
+            if _cb:
                 _cb(reg_type=reg_type, address=address, val=vals)
 
-            vals = self._create_response(request=request, reg_type=reg_type)
-            request.send_response(vals)
+            return request.send_response(vals)
         else:
             request.send_exception(Const.ILLEGAL_DATA_ADDRESS)
 


### PR DESCRIPTION
*Bug*

* If `on_get_cb` is defined, the second call to `self._create_response()` overwrites the value returned by `on_get_cb`.
* In other words: The value set by `on_get_cb` was swallowed.

*Bugfix*

* Simplified code
* Call `self._create_response()` only once.