### PR TITLE
Implement support for broadcast

### DIFF
--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,5 +1,5 @@
 # List external packages here
 # Avoid fixed versions
 # # to upload package to PyPi or other package hosts
-twine>=4.0.1,<5
+twine==6.*
 changelog2version>=0.5.0,<1

--- a/umodbus/const.py
+++ b/umodbus/const.py
@@ -137,6 +137,9 @@ CRC16_TABLE = (
     0x4100, 0x81C1, 0x8081, 0x4040
 )
 
+#: Broadcast address
+BROADCAST_ADDR = const(0x00)
+
 
 # Code to generate the CRC-16 lookup table:
 # def generate_crc16_table():

--- a/umodbus/const.py
+++ b/umodbus/const.py
@@ -104,6 +104,9 @@ FIXED_RESP_LEN = const(0x08)
 #: Modbus Application Protocol High Data Response length
 MBAP_HDR_LENGTH = const(0x07)
 
+#: Broadcast address
+BROADCAST_ADDR = const(0x00)
+
 #: CRC16 lookup table
 CRC16_TABLE = (
     0x0000, 0xC0C1, 0xC181, 0x0140, 0xC301, 0x03C0, 0x0280, 0xC241, 0xC601,
@@ -136,9 +139,6 @@ CRC16_TABLE = (
     0x4540, 0x8701, 0x47C0, 0x4680, 0x8641, 0x8201, 0x42C0, 0x4380, 0x8341,
     0x4100, 0x81C1, 0x8081, 0x4040
 )
-
-#: Broadcast address
-BROADCAST_ADDR = const(0x00)
 
 
 # Code to generate the CRC-16 lookup table:

--- a/umodbus/serial.py
+++ b/umodbus/serial.py
@@ -292,7 +292,7 @@ class Serial(CommonModbusFunctions):
     def _send_receive(self,
                       modbus_pdu: bytes,
                       slave_addr: int,
-                      count: bool) -> bytes|None:
+                      count: bool) -> Union[bytes, None]:
         """
         Send a modbus message and receive the reponse.
 


### PR DESCRIPTION
Hi,

I added support for broadcast messages.

Documentation can be found here: [Modbus_over_serial_line_V1.pdf](https://modbus.org/docs/Modbus_over_serial_line_V1.pdf) (see page 7/44)

> In **broadcast mode**, the master can send a request to all slaves.
No response is returned to broadcast requests sent by the master. The broadcast requests are necessarily writing commands. **All devices must accept the broadcast for writing function**. The address 0 is reserved to identify a broadcast exchange